### PR TITLE
Update header.html

### DIFF
--- a/web_interface/header.html
+++ b/web_interface/header.html
@@ -2,7 +2,7 @@
 <div id="topbar">
 	<a href="/"><img src="web_images/header.png" width="1360" alt="header broken" /></a>
 </div>
-    <script type="text/javascript" src="https://collect.maizegdb.org/s/c8813a998753850601eaa623d54ef1ec-T/en_US-xp7fh0/6338/3/1.4.15/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=14d7e41d"></script>
+    <script type="text/javascript" src="PATH/TO/YOUR/JIRA/INSTANCE"></script>
     <script type="text/javascript" src="js/api.js"></script>
     <script type="text/javascript">window.ATL_JQ_PAGE_PROPS =  {
 	"triggerFunction": function(showCollectorDialog) {


### PR DESCRIPTION
Removed our jira instance information from qTeller. This was causing qTeller jira tickets to be sent to our system when people deployed this app in their own environment.